### PR TITLE
optim error msg

### DIFF
--- a/src/cmd/rpc.rs
+++ b/src/cmd/rpc.rs
@@ -346,11 +346,7 @@ where
             let tx_hash = *m.get_one::<Hash>("tx_hash").unwrap();
             let c = &ctx.controller;
 
-            let tx = ctx
-                .rt
-                .block_on(c.get_tx(tx_hash))?
-                .map_err(|e| println!("{e}"))
-                .unwrap();
+            let tx = ctx.rt.block_on(c.get_tx(tx_hash))??;
             let tx_with_index = match ctx.rt.block_on(async move {
                 try_join!(c.get_tx_block_number(tx_hash), c.get_tx_index(tx_hash),)
             })? {
@@ -400,11 +396,7 @@ where
             let tx_hash = *m.get_one::<Hash>("tx_hash").unwrap();
             let c = &ctx.controller;
 
-            let cc_proof = ctx
-                .rt
-                .block_on(c.get_cross_chain_proof(tx_hash))?
-                .map_err(|e| println!("{e}"))
-                .unwrap();
+            let cc_proof = ctx.rt.block_on(c.get_cross_chain_proof(tx_hash))??;
 
             println!("{}", cc_proof.display());
             if m.contains_id("output") {


### PR DESCRIPTION
before
```bash
❯ cldi -c default g ccp 0x7895c7fffffe994c0785d966e808065ca66fe195222caa51860e15b17fb61ecc
status: InvalidArgument, message: "NoReceiptProof", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 17 May 2023 09:27:02 GMT", "content-length": "0"} }
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', src/cmd/rpc.rs:407:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

❯ cldi get tx 0x7895c7fffffe994c0785d966e808065ca66fe195222caa51860e15b17fb61ecc
status: InvalidArgument, message: "NoTransaction", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 17 May 2023 09:42:23 GMT", "content-length": "0"} }
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: ()', src/cmd/rpc.rs:353:18
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

after
```bash
❯ cldi -c default g ccp 0x7895c7fffffe994c0785d966e808065ca66fe195222caa51860e15b17fb61ecc
Error: status: InvalidArgument, message: "NoReceiptProof", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 17 May 2023 09:34:13 GMT", "content-length": "0"} }

❯ cldi get tx 0x7895c7fffffe994c0785d966e808065ca66fe195222caa51860e15b17fb61ecc
Error: status: InvalidArgument, message: "NoTransaction", details: [], metadata: MetadataMap { headers: {"content-type": "application/grpc", "date": "Wed, 17 May 2023 09:40:32 GMT", "content-length": "0"} }
```