### PR TITLE
fix linux-gnu release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,18 +26,6 @@ jobs:
           - build: linux-arm
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
-          - build: linux-musl
-            os: ubuntu-latest
-            target: x86_64-unknown-linux-musl
-          - build: linux-musl-arm
-            os: ubuntu-latest
-            target: aarch64-unknown-linux-musl
-          - build: win-msvc
-            os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - build: macos
-            os: macos-latest
-            target: x86_64-apple-darwin
           - build: macos-arm
             os: macos-latest
             target: aarch64-apple-darwin

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,5 +1,7 @@
 [target.x86_64-unknown-linux-gnu]
-dockerfile = "./dockerfiles/linux-x86/Dockerfile"
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:edge"
+pre-build = ["apt-get update && apt-get install -y libssl-dev libclang-dev protobuf-compiler"]
 
 [target.aarch64-unknown-linux-gnu]
-dockerfile = "./dockerfiles/linux-arm/Dockerfile"
+image = "ghcr.io/cross-rs/aarch64-unknown-linux-gnu:edge"
+pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install -y libssl-dev:arm64 libclang-dev protobuf-compiler"]

--- a/dockerfiles/linux-arm/Dockerfile
+++ b/dockerfiles/linux-arm/Dockerfile
@@ -1,5 +1,0 @@
-FROM ghcr.io/cross-rs/aarch64-unknown-linux-gnu:latest
-RUN dpkg --add-architecture arm64 && \
-    apt-get update && \
-    apt-get install --assume-yes libssl-dev:arm64 &&  \
-    apt-get install --assume-yes --no-install-recommends make wget librocksdb-dev libsnappy-dev liblz4-dev libzstd-dev libssl-dev pkg-config clang protobuf-compiler

--- a/dockerfiles/linux-x86/Dockerfile
+++ b/dockerfiles/linux-x86/Dockerfile
@@ -1,3 +1,0 @@
-FROM ghcr.io/cross-rs/x86_64-unknown-linux-gnu:latest
-RUN apt-get update && \
-    apt-get install --assume-yes --no-install-recommends make wget librocksdb-dev libsnappy-dev liblz4-dev libzstd-dev libssl-dev pkg-config clang protobuf-compiler


### PR DESCRIPTION
测试结果：linux-musl和gnu安装相同的libssl-dev也无法编译通过；windows因为引入了evm，其中cita-logger使用了signal-hook无法编译；mac_x86下cross没有提供镜像，自定义的镜像与linux-musl遇到一样的问题。
无法编译的环境需要通过修改代码来支持，可能需要下个版本恢复